### PR TITLE
Fix @http-resource processor to handle Python keywords on URI pattern parameters

### DIFF
--- a/nirum_wsgi.py
+++ b/nirum_wsgi.py
@@ -89,9 +89,9 @@ class WsgiApp:
             except KeyError as e:
                 raise AnnotationError('missing annotation parameter: ' +
                                       str(e))
-            parameters = {p
-                          for p in service_methods[method_name]
-                          if not p.startswith('_')}
+            parameters = frozenset(
+                service_methods[method_name]['_names'].values()
+            )
             unsatisfied_parameters = parameters - variables
             if unsatisfied_parameters:
                 raise AnnotationError(

--- a/schema-fixture/fixture.nrm
+++ b/schema-fixture/fixture.nrm
@@ -38,6 +38,11 @@ service unsatisfied-parameters-service (
     text foo-bar-baz(text foo, text bar, text baz),
 );
 
+service satisfied-parameters-service (
+    @http-resource(method="GET", path="/{from}/{to}/")
+    text python-keyword(text from, text to),
+);
+
 unboxed token (uuid);
 
 record complex-key-map ({point: point} value);

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,8 @@
 import collections
 import json
 
-from fixture import (BadRequest, MusicService, Unknown,
-                     UnsatisfiedParametersService)
+from fixture import (BadRequest, MusicService, SatisfiedParametersService,
+                     Unknown, UnsatisfiedParametersService)
 from pytest import fixture, mark, raises
 from six import text_type
 from werkzeug.test import Client
@@ -310,6 +310,10 @@ def test_unsatisfied_uri_template_parameters():
         '"/foo/{bar}/" does not fully satisfy all parameters of foo_bar_baz() '
         'method; unsatisfied parameters are: baz, foo'
     )
+    # As parameter names overlapped to Python keywords append an underscore
+    # to their names, it should deal with the case as well.
+    s = SatisfiedParametersService()
+    WsgiApp(s)  # Should not raise AnnotationError
 
 
 def test_http_resource_route(fx_test_client):


### PR DESCRIPTION
Fixed `@http-resource` processor's bug that hadn't properly handled Python keywords (e.g. `from`, `in`) on URI pattern parameters.  See also regression tests I added.

As `@http-resource` processor itself hasn't been released yet, I skipped the changelog.