### PR TITLE
Improve the way to handle return type errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info/
 *.pyc
+*.tix
 .*.swp
 .cache/
 .tox/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ To be released.
 - Since returning a disallowed value which does not match to the return type
   is the fault the server-side made, the HTTP status code for the case became
   ``500 Internal Server Error`` instead of ``400 Bad Request``.
+- For the mistakes returning ``None`` from a method having non-null return type,
+  now it became to show a more readable and debug-friendly message with a proper
+  response instead of uncaught Python exception.
 - ``WsgiApp.url_map`` attribute was gone.
 - ``/ping/`` resource was gone.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ To be released.
   as well.
 - Added ``AnnotationError``, ``NoJsonError``, and ``ServiceMethodError``
   exceptions.
+- Since returning a disallowed value which does not match to the return type
+  is the fault the server-side made, the HTTP status code for the case became
+  ``500 Internal Server Error`` instead of ``400 Bad Request``.
 - ``WsgiApp.url_map`` attribute was gone.
 - ``/ping/`` resource was gone.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ To be released.
 - Since returning a disallowed value which does not match to the return type
   is the fault the server-side made, the HTTP status code for the case became
   ``500 Internal Server Error`` instead of ``400 Bad Request``.
+  Also now it writes logs using ``logging`` module.
 - For the mistakes returning ``None`` from a method having non-null return type,
   now it became to show a more readable and debug-friendly message with a proper
   response instead of uncaught Python exception.

--- a/nirum_wsgi.py
+++ b/nirum_wsgi.py
@@ -387,16 +387,17 @@ class WsgiApp:
         if type_hints.get('_v', 1) >= 2:
             return_type = return_type()
         if not self._check_return_type(return_type, result):
-            return self.error(
-                500,
-                request,
-                message="Incorrect return type '{0}' "
-                        "for '{1}'. expected '{2}'.".format(
-                            typing._type_repr(result.__class__),
-                            service_method,
-                            typing._type_repr(return_type)
-                        )
+            message = '''The return type of the {0}() method is {1}, but its \
+server-side implementation has tried to return a value of an invalid type.  \
+It is an internal server error and should be fixed by server-side.'''.format(
+                service_method.replace('_', '-'),
+                typing._type_repr(return_type),
+                # FIXME: It'd better not show Python name of the return type,
+                # but its IDL behind name instead.  Currently the Nirum
+                # compiler doesn't generate metadata having behind names of
+                # nethod return/parameter types.
             )
+            return self.error(500, request, message=message)
         else:
             return self._raw_response(200, serialize_meta(result))
 

--- a/nirum_wsgi.py
+++ b/nirum_wsgi.py
@@ -388,7 +388,7 @@ class WsgiApp:
             return_type = return_type()
         if not self._check_return_type(return_type, result):
             return self.error(
-                400,
+                500,
                 request,
                 message="Incorrect return type '{0}' "
                         "for '{1}'. expected '{2}'.".format(

--- a/schema-fixture/fixture.nrm
+++ b/schema-fixture/fixture.nrm
@@ -75,3 +75,8 @@ service statistics-service (
 unboxed token (uuid);
 
 record complex-key-map ({point: point} value);
+
+service null-disallowed-method-service (
+    point null-disallowed-method (),
+    point def (),
+);

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ install_requires = [
 tests_require = [
     'flake8-import-order >= 0.12, < 1.0',
     'flake8-import-order-spoqa >= 1.0.0, < 2.0.0',
-    'pytest >= 3.1.2, < 4.0.0',
+    'pytest >= 3.3.2, < 4.0.0',
     'pytest-flake8 >= 0.9.1, < 1.0.0',
     'requests-mock >= 1.3.0, < 1.4.0',
 ]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def readme(name='README.rst'):
 
 def get_version():
     module_path = os.path.join(os.path.dirname(__file__), 'nirum_wsgi.py')
-    module_file = open(module_path)
+    module_file = open(module_path, 'rb')
     try:
         module_code = module_file.read()
     finally:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def get_version():
 
 setup_requires = []
 install_requires = [
-    'nirum >= 0.6.0',
+    'nirum >= 0.6.1',
     'six',
     'Werkzeug >= 0.11, < 1.0',
 ]

--- a/tests.py
+++ b/tests.py
@@ -8,7 +8,7 @@ from fixture import (BadRequest, CorsVerbService, MusicService,
                      Unknown, UnsatisfiedParametersService)
 from nirum.deserialize import deserialize_meta
 from pytest import fixture, mark, raises
-from six import text_type
+from six import PY2, text_type
 from six.moves import urllib
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
@@ -146,8 +146,10 @@ def test_wsgi_app_error(fx_test_client):
         {
             '_type': 'error',
             '_tag': 'internal_server_error',
-            'message': "Incorrect return type 'int' for 'incorrect_return'. "
-                       "expected '{}'.".format(text_type.__name__)
+            'message': '''The return type of the incorrect-return() method is \
+{0}, but its server-side implementation has tried to return a value of \
+an invalid type.  It is an internal server error and should be fixed by \
+server-side.'''.format('unicode' if PY2 else 'str')
         }
     )
 

--- a/tests.py
+++ b/tests.py
@@ -142,10 +142,10 @@ def test_wsgi_app_error(fx_test_client):
     # incorrect return
     assert_response(
         fx_test_client.post('/?method=incorrect_return'),
-        400,
+        500,
         {
             '_type': 'error',
-            '_tag': 'bad_request',
+            '_tag': 'internal_server_error',
             'message': "Incorrect return type 'int' for 'incorrect_return'. "
                        "expected '{}'.".format(text_type.__name__)
         }

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = buildfixture,{py27,py34,py35,py36}-{werkzeug011,werkzeug012},docs
+envlist = buildfixture,{py27,py34,py35,py36}-{werkzeug011,werkzeug012,werkzeug013,werkzeug014},docs
 skipsdist = true
 
 [testenv]
@@ -7,6 +7,8 @@ skip_install = true
 deps =
     werkzeug011: Werkzeug >= 0.11, < 0.12
     werkzeug012: Werkzeug >= 0.12, < 0.13
+    werkzeug013: Werkzeug >= 0.13, < 0.14
+    werkzeug014: Werkzeug >= 0.14, < 0.15
 commands =
     pip install -f {distdir} -e {env:FIXTURE_PATH:{distdir}/schema_fixture/}
     pip install -f {distdir} -e .[tests]

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
 commands =
     rst2html.py --strict CHANGES.rst
     rst2html.py --strict README.rst
-    python3 setup.py --long-description | rst2html.py --strict
+    python3 setup.py --long-description | rst2html.py -i utf-8 -o utf-8 --strict
 
 [pytest]
 addopts = --ff --flake8 nirum_wsgi.py tests.py


### PR DESCRIPTION
- First of all, since return type errors are made by server-side, not client-side, it's entirely server's fault, so it should respond with `500 Internal Server Error` instead of `400 Bad Request`.
- It had raised uncaught `ValueError` instead of any proper HTTP response when a method return `None` despite its return type is not optional.  All uncaught exceptions shouldn't be raised from WSGI apps anyway.  Although `ValueError` itself is due to `deserialize_record_type()` function (which is from nirum-python), I fixed it by early check of `None` values as a special case.
- Made the case easier to debug by adjusting error messages and recording error logs.
- Includes side patches that fix broken tests for certain cases.