### PR TITLE
Make nirum-server command able to import from CWD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,6 @@ script:
   elif [[ "$TRAVIS_TAG" != "" ]]; then
     ! grep -i "to be released" CHANGES.rst
   else
+    [[ "$TRAVIS_COMMIT_RANGE" = "" ]] || \
     [[ "$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep CHANGES\.rst)" != "" ]]
   fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ To be released.
   response instead of uncaught Python exception.
 - ``WsgiApp.url_map`` attribute was gone.
 - ``/ping/`` resource was gone.
+- Fix ``nirum-server`` command able to import a Python module/package from
+  the current working directory (``.``; CWD).
 
 .. _#205: https://github.com/spoqa/nirum/issues/205
 .. _#130: https://github.com/spoqa/nirum/issues/130

--- a/nirum_wsgi.py
+++ b/nirum_wsgi.py
@@ -8,7 +8,9 @@ import collections
 import itertools
 import json
 import logging
+import os
 import re
+import sys
 import typing
 
 from nirum._compat import get_union_types, is_union_type
@@ -707,6 +709,8 @@ def main():
                         action='store_true', default=False)
     parser.add_argument('service', help='Import path to service instance')
     args = parser.parse_args()
+    if not ('.' in sys.path or os.getcwd() in sys.path):
+        sys.path.insert(0, os.getcwd())
     service = import_string(args.service)
     run_simple(
         args.host, args.port, WsgiApp(service),


### PR DESCRIPTION
The `nirum-server` command had been unable to import a Python module/package from the current working directory (CWD) since there's no the `'.'` in `sys.path` (although I'm not sure why there is no `'.'` in `sys.path`).  This patch fixes the bug.