### PR TITLE
Make nirum-wsgi independent from Werkzeug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Version 0.4.0
 
 To be released.
 
+- Made ``nirum-python-wsgi`` independent from `Werkzeug`_.  [`#284`_]
+
+.. _#284: https://github.com/spoqa/nirum/issues/284
+.. _Werkzeug: http://werkzeug.pocoo.org/
+
 
 Version 0.3.0
 -------------

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup_requires = []
 install_requires = [
     'nirum >= 0.6.3',
     'six',
-    'Werkzeug >= 0.11, < 1.0',
 ]
 tests_require = [
     'flake8-import-order >= 0.17.1, < 1.0',
@@ -52,6 +51,7 @@ tests_require = [
     'pytest >= 3.5.1, < 4.0.0',
     'pytest-flake8 >= 1.0.1, < 1.1.0',
     'requests-mock >= 1.5.0, < 1.6.0',
+    'Werkzeug >= 0.11, < 1.0',
 ]
 extras_require = {
     'tests': tests_require,

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,13 @@
 [tox]
-envlist = buildfixture,{py27,py34,py35,py36}-{werkzeug011,werkzeug012,werkzeug013,werkzeug014},docs
+envlist = buildfixture,{py27,py34,py35,py36},docs
 skipsdist = true
 
 [testenv]
 skip_install = true
-deps =
-    werkzeug011: Werkzeug >= 0.11, < 0.12
-    werkzeug012: Werkzeug >= 0.12, < 0.13
-    werkzeug013: Werkzeug >= 0.13, < 0.14
-    werkzeug014: Werkzeug >= 0.14, < 0.15
 commands =
     pip install -f {distdir} -e {env:FIXTURE_PATH:{distdir}/schema_fixture/}
     pip install -f {distdir} -e .[tests]
-    pytest -v
+    pytest -v {posargs}
 
 [testenv:buildfixture]
 skipinstall = true


### PR DESCRIPTION
Related issue: https://github.com/spoqa/nirum/issues/284

- Added `nirum_wsgi.Request` & `nirum_wsgi.Response` to handle a WSGI request/response easily.
- Replaced Werkzeug object with it.
- Removed dependencies on tox as well.

Please review this PR @dahlia.